### PR TITLE
Solution for partial path overlap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+zatch
+zatch.o

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ $ sudo make install
 
 ## Documentation
 
-For documentation please refer to the manual.
+For documentation please refer to the manual (`$ man zatch`).
 
 
 ## License


### PR DESCRIPTION
Fixes partial path overlap by ensuring the longest available path match takes precedence over the first available